### PR TITLE
Fix: Prevent Out-of-Bounds Access in control_loop

### DIFF
--- a/csrc/real_humanoid.cpp
+++ b/csrc/real_humanoid.cpp
@@ -115,7 +115,7 @@ void RealHumanoid::control_loop() {
 
     case STATE_RL_RUNNING:
       /* In this state, the robot will follow the policy */
-      for (int i = 0; i < N_JOINTS; i += 1) {
+      for (int i = 0; i < N_LOWLEVEL_COMMANDS; i += 1) {
         position_target[i] = lowlevel_commands[i];
       }
 


### PR DESCRIPTION
### Problem  
In the `control_loop()` function, while in `STATE_RL_RUNNING`, the following code was used:

```cpp
for (int i = 0; i < N_JOINTS; i += 1) {
    position_target[i] = lowlevel_commands[i];
}
```
This loop iterates over `N_JOINTS`, but `lowlevel_commands` only has `N_LOWLEVEL_COMMANDS` elements (12). When `N_JOINTS` is greater than `N_LOWLEVEL_COMMANDS`, this causes out-of-bounds memory access, which is undefined behavior and can lead to crashes or data corruption.

### Solution  
Change the loop to iterate over `N_LOWLEVEL_COMMANDS` instead of `N_JOINTS`:

```cpp
for (int i = 0; i < N_LOWLEVEL_COMMANDS; i += 1) {
    position_target[i] = lowlevel_commands[i];
}
```

### Impact  
- Prevents out-of-bounds access for `lowlevel_commands`